### PR TITLE
fix crash because of empty self.data.items

### DIFF
--- a/smartfs.lua
+++ b/smartfs.lua
@@ -594,6 +594,9 @@ smartfs.element("list",{
                                      ";"
 
                 --loop through the list's items and add them to the formspec
+				if not self.data.items then
+					self.data.items = {" "}
+				end
                 for i,value in ipairs(self.data.items) do
                     listformspec = listformspec..value..","
                 end


### PR DESCRIPTION
When using the code snippets you gave me (https://github.com/rubenwardy/smartfs/issues/1), minetest crashes because self.data.items is nil. This should fix it.
