### PR TITLE
Add show_inv parameter to smartfs.add_to_inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ Now that you have located your element you can modify it.
     button1:setPos(4,0)
 
 ## Inventory Support
-Smartfs supports adding a button to Sfinv, Inventory+, or Unified Inventory which will open one of your own custom forms. Use the smartfs.add\_to\_inventory(form, icon, title) function where form is the smartfs form linked to by the button, icon is the button image (only for unified inventory), and title is the button text (for inventory+ and sfinv).
+Smartfs supports adding a button to Sfinv, Inventory+, or Unified Inventory which will open one of your own custom forms. Use the smartfs.add\_to\_inventory(form, icon, title) function where form is the smartfs form linked to by the button, icon is the button image (only for unified inventory), title is the button text (for inventory+ and sfinv), and show_inv specifies whether to include the player inventory by default (for unified inventory and sfinv).
 
-    smartfs.add_to_inventory(form, icon, title)
+    smartfs.add_to_inventory(form, icon, title, show_inv)
 
 ## Dynamic forms
 Dynamic forms allow you to make a form without having to register it before the game finished loading.

--- a/docs/API.md
+++ b/docs/API.md
@@ -4,7 +4,7 @@
 * smartfs.create( name,function ) - creates a new form and adds elements to it by running the function. Use before Minetest loads. (like minetest.register_node)
 * smartfs.element( name, data ) - creates a new element type.
 * smartfs.dynamic( formname, playername ) - creates a dynamic form. Returns state. See example.lua for example. Remember to call state:show()
-* smartfs.add_to_inventory(form, icon, title) - Adds a form to an installed advanced inventory. Returns true on success.
+* smartfs.add_to_inventory(form, icon, title, show_inv) - Adds a form to an installed advanced inventory. Returns true on success.
 * smartfs.set_player_inventory(form) - Set the form as players main inventory for all player
 * smartfs.inventory_mod() - Returns the name of an installed and supported inventory mod that will be used above, or nil.
 * smartfs.override_load_checks() - Allows you to use smartfs.create after the game loads. Not recommended!
@@ -16,7 +16,7 @@
 * form:attach_to_node(nodepos, params) - Attach a form to a node meta (usable in register_node's constructor, on_placenode, or dynamically)
 
 ## Supported locations
-* unified_inventory or inventory_plus plugins - assigned by smartfs.add_to_inventory() - auto-detection which inventory should be used
+* unified_inventory, inventory_plus, or sfinv plugins - assigned by smartfs.add_to_inventory() - auto-detection which inventory should be used
 * player / show_formspec() - used for form:show(player)
 * (main) inventory - assigned by smartfs.set_player_inventory()
 * nodemeta - assigned by form:attach_to_node(nodepos, params)

--- a/smartfs.lua
+++ b/smartfs.lua
@@ -89,7 +89,7 @@ end
 ------------------------------------------------------
 -- Smartfs Interface - Adds a form to an installed advanced inventory. Returns true on success.
 ------------------------------------------------------
-function smartfs.add_to_inventory(form, icon, title)
+function smartfs.add_to_inventory(form, icon, title, show_inv)
 	local ldef
 	local invmod = smartfs.inventory_mod()
 	if  invmod then
@@ -97,7 +97,7 @@ function smartfs.add_to_inventory(form, icon, title)
 	else
 		return false
 	end
-	return ldef.add_to_inventory(form, icon, title)
+	return ldef.add_to_inventory(form, icon, title, (show_inv == nil) and true or show_inv)
 end
 
 ------------------------------------------------------
@@ -118,7 +118,7 @@ end
 ------------------------------------------------------
 -- Unified inventory plugin
 smartfs._ldef.unified_inventory = {
-	add_to_inventory = function(form, icon, title)
+	add_to_inventory = function(form, icon, title, show_inv)
 		unified_inventory.register_button(form.name, {
 			type = "image",
 			image = icon,
@@ -139,7 +139,7 @@ smartfs._ldef.unified_inventory = {
 						return ""
 					end
 				end
-				return {formspec = state:_buildFormspec_(false)}
+				return {formspec = state:_buildFormspec_(false), draw_inventory = show_inv}
 			end
 		})
 	end,
@@ -185,7 +185,7 @@ smartfs._ldef.inventory_plus = {
 
 -- Sfinv plugin
 smartfs._ldef.sfinv = {
-	add_to_inventory = function(form, icon, title)
+	add_to_inventory = function(form, icon, title, show_inv)
 		sfinv.register_page(form.name, {
 			title = title,
 			get = function(self, player, context)
@@ -204,7 +204,7 @@ smartfs._ldef.sfinv = {
 					end
 				end
 				local fs = state:_buildFormspec_(false)
-				return sfinv.make_formspec(player, context, fs, true)
+				return sfinv.make_formspec(player, context, fs, show_inv)
 			end,
 			on_player_receive_fields = function(self, player, _, fields)
 				local name = player:get_player_name()


### PR DESCRIPTION
This parameter tells the inventory mod whether to automatically add the player inventory to the formspec or not.

I have the parameter defaulting to `true` if not specified, to maintain backwards compatibility. Let me know if you'd rather it default to `false`.

Closes #49 