### PR TITLE
Add inventory:setList(list) and inventory:getList() to set the inventory list name.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -148,6 +148,8 @@
   * element:useDetached( name ) - use a detached inventory with the given name
   * element:usePlayer( name ) - use a player inventory other than the current player
 * element:getLocation() - returns the inventory location (default: current_player)
+* element:setList( list ) - set a custom inventory list name or nil for the default (the element's name)
+* element:getList() - returns the list (defaults to the element's name)
 * element:setIndex( index ) - set the inventory starting index
 * element:getIndex() - returns the inventory starting index
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -149,7 +149,7 @@
   * element:usePlayer( name ) - use a player inventory other than the current player
 * element:getLocation() - returns the inventory location (default: current_player)
 * element:setList( list ) - set a custom inventory list name or nil for the default (the element's name)
-* element:getList() - returns the list (defaults to the element's name)
+* element:getList() - returns the list name (defaults to the element's name)
 * element:setIndex( index ) - set the inventory starting index
 * element:getIndex() - returns the inventory starting index
 

--- a/smartfs.lua
+++ b/smartfs.lua
@@ -1454,7 +1454,7 @@ smartfs.element("inventory", {
 	setList = function(self, list)
 		self.data.list = list
 	end,
-	getList = function(self, list)
+	getList = function(self)
 		return self.data.list or self.name
 	end,
 	setIndex = function(self,index)

--- a/smartfs.lua
+++ b/smartfs.lua
@@ -1421,7 +1421,7 @@ smartfs.element("inventory", {
 		return "list["..
 			(self.data.invlocation or "current_player") ..
 			";"..
-			self.name..    --no namespacing
+			(self.data.list or self.name) ..    --no namespacing
 			";"..
 			self.data.pos.x..","..self.data.pos.y..
 			";"..
@@ -1450,6 +1450,12 @@ smartfs.element("inventory", {
 	end,
 	useDetached = function(self, name)
 		self.data.invlocation = "detached:" .. name
+	end,
+	setList = function(self, list)
+		self.data.list = list
+	end,
+	getList = function(self, list)
+		return self.data.list or self.name
 	end,
 	setIndex = function(self,index)
 		self.data.index = index

--- a/smartfs.lua
+++ b/smartfs.lua
@@ -1416,12 +1416,15 @@ smartfs.element("inventory", {
 		assert(self.data.pos and self.data.pos.x and self.data.pos.y, "list needs valid pos")
 		assert(self.data.size and self.data.size.w and self.data.size.h, "list needs valid size")
 		assert(self.name, "list needs name")
+
+		-- Default the list name to the element name.
+		self.data.list = self.name
 	end,
 	build = function(self)
 		return "list["..
 			(self.data.invlocation or "current_player") ..
 			";"..
-			(self.data.list or self.name) ..    --no namespacing
+			self.data.list ..
 			";"..
 			self.data.pos.x..","..self.data.pos.y..
 			";"..
@@ -1452,10 +1455,10 @@ smartfs.element("inventory", {
 		self.data.invlocation = "detached:" .. name
 	end,
 	setList = function(self, list)
-		self.data.list = list
+		self.data.list = list or self.name
 	end,
 	getList = function(self)
-		return self.data.list or self.name
+		return self.data.list
 	end,
 	setIndex = function(self,index)
 		self.data.index = index


### PR DESCRIPTION
This allows multiple inventory elements with the same list name but different inventory locations.
Example: the "main" list in a chest and the player's "main" list. There is currently a conflict since they both *must* have the same element name, which smartfs doesn't like.